### PR TITLE
cp タスクを実装した

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ Define task
 | options | Object |  Optional settings |
 
 
+### `cp(linkages, options) -> function`
+
+Define task
+
+| Param | type | Description |
+| ---- | --- | ----------- |
+| linkages | Object.&lt;string, string&gt; |  Directory copy ruling |
+| options | Object |  Optional settings |
+| options.force | boolean |  Force create |
+
+
 ### `define(options) -> function`
 
 Define task

--- a/lib/cp.js
+++ b/lib/cp.js
@@ -1,0 +1,43 @@
+/**
+ * Define task
+ * @function cp
+ * @param {Object.<string, string>} linkages - Directory copy ruling
+ * @param {Object} [options={}] - Optional settings
+ * @param {boolean} [options.force=false] - Force create
+ * @returns {function} Defined task
+ */
+'use strict'
+
+const co = require('co')
+const path = require('path')
+const { copyDirAsync, existsAsync } = require('asfs')
+
+/** @lends cp */
+function cp (linkages = {}, options = {}) {
+  let { force = true } = options
+  function task (ctx) {
+    let { cwd, logger } = ctx
+    return co(function * () {
+      for (let src of Object.keys(linkages)) {
+        let dest = linkages[ src ]
+        let absSrc = path.resolve(cwd, src)
+        let absDest = path.resolve(cwd, dest)
+        let srcExists = yield existsAsync(absSrc)
+        if (!srcExists) {
+          console.warn(`Source not exists: ${absSrc}`)
+          continue
+        }
+        let destExists = yield existsAsync(absDest)
+        if (destExists && !force) {
+          continue
+        }
+        yield copyDirAsync(absSrc, absDest)
+        logger.debug(`Directory copied: ${path.relative(cwd, absSrc)} -> ${path.relative(cwd, absDest)}`)
+      }
+    })
+  }
+
+  return Object.assign(task, {})
+}
+
+module.exports = cp

--- a/lib/define.js
+++ b/lib/define.js
@@ -11,8 +11,9 @@ const mkdir = require('./mkdir')
 const chmod = require('./chmod')
 const symlink = require('./symlink')
 const del = require('./del')
+const cp = require('./cp')
 
-const creators = { mkdir, chmod, symlink, del }
+const creators = { mkdir, chmod, symlink, del, cp }
 
 /** @lends define */
 function define (options = {}) {
@@ -32,5 +33,3 @@ function define (options = {}) {
 }
 
 module.exports = Object.assign(define, creators)
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Pon task for file system
  * @module pon-task-fs
- * @version 2.2.1
+ * @version 2.2.2
  */
 
 'use strict'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pon-task-fs",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Pon task for file system",
   "main": "lib",
   "browser": "shim/browser",

--- a/test/cp_test.js
+++ b/test/cp_test.js
@@ -1,0 +1,34 @@
+/**
+ * Test case for cp.
+ * Runs with mocha.
+ */
+'use strict'
+
+const cp = require('../lib/cp.js')
+const ponContext = require('pon-context')
+const assert = require('assert')
+const co = require('co')
+
+describe('cp', function () {
+  this.timeout(3000)
+
+  before(() => co(function * () {
+
+  }))
+
+  after(() => co(function * () {
+
+  }))
+
+  it('Copy', () => co(function * () {
+    let task = cp({
+      '../../test': `foo`
+    }, { force: true })
+    let ctx = ponContext({
+      cwd: `${__dirname}/../tmp/testing-cp`
+    })
+    yield task(ctx)
+  }))
+})
+
+/* global describe, before, after, it */


### PR DESCRIPTION
symlink とほとんど同じ使い方
```js
const { cp } = require('pon-task-fs')
cp({
  srcDir: 'destDir'
})
```